### PR TITLE
Fixing chart labels not matching data being drawn

### DIFF
--- a/src/SmartHotel.Clients/SmartHotel.Clients/Controls/LightChart.cs
+++ b/src/SmartHotel.Clients/SmartHotel.Clients/Controls/LightChart.cs
@@ -50,13 +50,14 @@ namespace SmartHotel.Clients.Core.Controls
         protected override void DrawCaption(SKCanvas canvas, int cx, int cy, float radius, float relativeScaleWidth,
             float strokeWidth)
         {
-            var values = Entries.ToList();
-            var currentValue = values.FirstOrDefault();
+	        if (CurrentValueEntry != null)
+	        {
+		        canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"{CurrentValueEntry.Value}%", SKColor.Parse("#283748"),
+			        LabelTextSize * relativeScaleWidth,
+			        new SKPoint(cx - CaptionMargin, cy / 2f + 3 * strokeWidth), SKTextAlign.Center);
+	        }
 
-            canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"{currentValue?.Value}%", SKColor.Parse("#283748"), LabelTextSize * relativeScaleWidth,
-                new SKPoint(cx - CaptionMargin, cy / 2f + 3 * strokeWidth), SKTextAlign.Center);
-
-            // uncomment to add Desired value
+	        // uncomment to add Desired value
             //var desiredValue = values.Skip(1).Take(1).FirstOrDefault();
             //canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"Desired: {desiredValue?.Value}%", SKColor.Parse("#378D93"), LabelTextSize * relativeScaleWidth,
             //    new SKPoint(cx - CaptionMargin, cy / 2f + 3 * strokeWidth * 1.45f), SKTextAlign.Center);

--- a/src/SmartHotel.Clients/SmartHotel.Clients/Controls/TemperatureChart.cs
+++ b/src/SmartHotel.Clients/SmartHotel.Clients/Controls/TemperatureChart.cs
@@ -20,7 +20,11 @@ namespace SmartHotel.Clients.Core.Controls
 
         public float StartAngle { get; set; } = -180;
 
-        protected float AbsoluteMinimum => Entries.Select(x => x.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Min(x => Math.Abs(x));
+		public Entry CurrentValueEntry { get; set; }
+
+		public Entry DesiredValueEntry { get; set; }
+
+		protected float AbsoluteMinimum => Entries.Select(x => x.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Min(x => Math.Abs(x));
 
         private float AbsoluteMaximum => Entries.Select(x => x.Value).Concat(new[] { MaxValue, MinValue, InternalMinValue ?? 0 }).Max(x => Math.Abs(x));
 
@@ -80,13 +84,21 @@ namespace SmartHotel.Clients.Core.Controls
             canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"{medium}°", SKColors.Black, LabelTextSize * relativeScaleWidth, new SKPoint(cx, cy - radius - strokeWidth - 2 * relativeScaleWidth), SKTextAlign.Center);
             canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"{AbsoluteMaximum}°", SKColors.Black, LabelTextSize * relativeScaleWidth, new SKPoint(cx + radius + strokeWidth + CaptionMargin, cy), SKTextAlign.Center);
 
-            var values = Entries.ToList();
-            var currentValue = values.FirstOrDefault();
-            var desiredValue = values.Skip(1).Take(1).FirstOrDefault();
 
             var degreeSign = '°';
-            canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"Current: {currentValue?.Value}{degreeSign}", SKColor.Parse("#174A51"), LabelTextSize * relativeScaleWidth, new SKPoint(cx, cy - radius * 1.8f / 4f), SKTextAlign.Center);
-            canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"Desired: {desiredValue?.Value}{degreeSign}", SKColor.Parse("#378D93"), LabelTextSize * relativeScaleWidth, new SKPoint(cx, cy - radius * 0.9f / 4f), SKTextAlign.Center);
+	        if (CurrentValueEntry != null)
+	        {
+		        canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"Current: {CurrentValueEntry.Value}{degreeSign}",
+			        SKColor.Parse("#174A51"), LabelTextSize * relativeScaleWidth, new SKPoint(cx, cy - radius * 1.8f / 4f),
+			        SKTextAlign.Center);
+	        }
+
+	        if (DesiredValueEntry != null)
+	        {
+		        canvas.DrawCaptionLabels(string.Empty, SKColor.Empty, $"Desired: {DesiredValueEntry?.Value}{degreeSign}",
+			        SKColor.Parse("#378D93"), LabelTextSize * relativeScaleWidth, new SKPoint(cx, cy - radius * 0.9f / 4f),
+			        SKTextAlign.Center);
+	        }
         }
         
     }

--- a/src/SmartHotel.Clients/SmartHotel.Clients/ViewModels/HomeViewModel.cs
+++ b/src/SmartHotel.Clients/SmartHotel.Clients/ViewModels/HomeViewModel.cs
@@ -160,6 +160,8 @@ namespace SmartHotel.Clients.Core.ViewModels
             var desiredChartValue = new Entry(roomTemperature.Desired.RawValue) { Color = SKColor.Parse("#378D93") };
             var maxChartValue = new Entry(roomTemperature.Maximum.RawValue) { Color = SKColor.Parse("#D4D4D4") };
 
+	        chartData.CurrentValueEntry = currentChartValue;
+	        chartData.DesiredValueEntry = desiredChartValue;
 
             if (roomTemperature.Value.RawValue > roomTemperature.Desired.RawValue)
                 chartData.Entries = new[] { maxChartValue, currentChartValue, desiredChartValue  };
@@ -181,6 +183,9 @@ namespace SmartHotel.Clients.Core.ViewModels
 
             var currentChartValue = new Entry(light.Value.RawValue) { Color = SKColor.Parse("#174A51") };
             var maxChartValue = new Entry(light.Maximum.RawValue) { Color = SKColor.Parse("#D4D4D4") };
+
+	        chartData.CurrentValueEntry = currentChartValue;
+
             chartData.Entries = new[] { maxChartValue, currentChartValue };
 
             return chartData;


### PR DESCRIPTION
Because of the need to reorder the chart entries, need to explicitly set the CurrentValueEntry and/DesiredValueEntry properties on the charts. The captions are only drawn if they are provided.